### PR TITLE
Update PSK2

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,0 +1,15 @@
+const superagent = require('superagent')
+const plugin = require('ilp-plugin')()
+const superagentIlp = require('.')(superagent, plugin)
+
+async function run () {
+  await plugin.connect()
+  const res = await superagentIlp
+    .post('http://localhost:8080/hello')
+    .pay(2000) // pays _up to_ 2000 base units of your ledger, as configured for ilp-plugin
+
+  console.log(res.body)
+  // -> { message: 'Hello World!' }
+}
+
+run()

--- a/package-lock.json
+++ b/package-lock.json
@@ -676,12 +676,6 @@
       "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
       "dev": true
     },
-    "extensible-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/extensible-error/-/extensible-error-1.0.2.tgz",
-      "integrity": "sha512-kXU1FiTsGT8PyMKtFM074RK/VBpzwuQJicAHqBpsPDeTXBQiSALPjkjKXlyKdG/GP6lR7bBaEkq8qdoO2geu9g==",
-      "dev": true
-    },
     "external-editor": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
@@ -750,15 +744,6 @@
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
-      }
-    },
-    "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
-      "dev": true,
-      "requires": {
-        "is-function": "1.0.1"
       }
     },
     "form-data": {
@@ -884,34 +869,6 @@
       "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
-    "ilp": {
-      "version": "github:interledgerjs/ilp#fc4c35727f3c6cd4274dd51d726dc3b12ca3bee9",
-      "dev": true,
-      "requires": {
-        "bignumber.js": "5.0.0",
-        "debug": "3.1.0",
-        "extensible-error": "1.0.2",
-        "ilp-compat-plugin": "2.0.3",
-        "ilp-packet": "2.1.2",
-        "ilp-protocol-ildcp": "1.0.0",
-        "moment": "2.20.1",
-        "oer-utils": "1.3.4",
-        "parse-headers": "2.0.1",
-        "superagent": "3.8.2",
-        "uuid": "3.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "ilp-compat-plugin": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ilp-compat-plugin/-/ilp-compat-plugin-2.0.3.tgz",
@@ -949,11 +906,11 @@
       "integrity": "sha1-2No5b1U+Zk83PoVJTkj9khfxrRQ=",
       "dev": true,
       "requires": {
-        "ilp-plugin-btp": "github:interledgerjs/ilp-plugin-btp#1a9245b53ec08fdc611760a5416d13c3baff76ff"
+        "ilp-plugin-btp": "github:interledgerjs/ilp-plugin-btp#b2393deba1d43ca38c06cc2732bd805df940a66c"
       }
     },
     "ilp-plugin-btp": {
-      "version": "github:interledgerjs/ilp-plugin-btp#1a9245b53ec08fdc611760a5416d13c3baff76ff",
+      "version": "github:interledgerjs/ilp-plugin-btp#b2393deba1d43ca38c06cc2732bd805df940a66c",
       "dev": true,
       "requires": {
         "base64url": "2.0.0",
@@ -984,9 +941,9 @@
       }
     },
     "ilp-protocol-psk2": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.2.1.tgz",
-      "integrity": "sha512-mMeT6iqjaca5DEgNwOENgEIw4E+nSN1v9tPTpPRVaTYr79VQe7NGR5wLp3kk1bY7LYWh/AWemw3XJwkDmyDoPw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/ilp-protocol-psk2/-/ilp-protocol-psk2-0.3.0.tgz",
+      "integrity": "sha512-3bDMpTAzNCygobT0Wz0qxZ+wjGcjeOB2INU9H2ZSoynMD2vO3Wna0qaNroyGLG1Yhgk34zPIZ5glmdsuj9lhfA==",
       "requires": {
         "bignumber.js": "5.0.0",
         "debug": "3.1.0",
@@ -1076,12 +1033,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
       "dev": true
     },
     "is-path-cwd": {
@@ -1324,12 +1275,6 @@
         "minimist": "0.0.8"
       }
     },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1421,16 +1366,6 @@
       "dev": true,
       "requires": {
         "p-limit": "1.1.0"
-      }
-    },
-    "parse-headers": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
-      "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
-      "dev": true,
-      "requires": {
-        "for-each": "0.3.2",
-        "trim": "0.0.1"
       }
     },
     "parse-json": {
@@ -1902,12 +1837,6 @@
       "requires": {
         "os-tmpdir": "1.0.2"
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-      "dev": true
     },
     "tryit": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
   "dependencies": {
     "ilp": "interledgerjs/ilp#refactor/st-lpi2",
     "ilp-compat-plugin": "^2.0.3",
-    "ilp-protocol-psk2": "^0.2.0"
+    "ilp-protocol-psk2": "^0.3.0"
   }
 }


### PR DESCRIPTION
based on the changes in https://github.com/interledgerjs/ilp-protocol-psk2/pull/19

this should be backwards compatible with old koa-ilp modules because PSK2 is backwards compatible and https://github.com/interledgerjs/ilp-protocol-psk2/pull/19/commits/cf2fbdbd9e6fc28d591dcb187266e50c566793f3 makes it send the paymentId when it falls back to sending legacy packets